### PR TITLE
Making RT tests more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased - 2021-11-10
+[GP-2875](https://jira.oicr.on.ca/browse/GP-2875) Making RT scripts more robust
 ## 1.2 - 2021-06-01
  - Migration to Vidarr
 ## 1.2 - 2020-07-02

--- a/calculate.sh
+++ b/calculate.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd $1
-ls | sed 's/.*\.//' | sort | uniq -c

--- a/compare.sh
+++ b/compare.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-diff -s <(sort $1) <(sort $2)

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+cd $1
+
+#  .csv rpkmData = rpkmTable.rpkmTable
+#  .png image - we are not checking this, binary content
+#  .pdf reportPdf file to be checked, need to remove creation date from the header
+#  .json is tested with jq
+
+echo ".csv files:"
+# calculate md5sum, no stochastic content expected
+find . -name "*.csv" | xargs md5sum
+
+echo ".pdf Files:"
+# Need to exclude some date-specific information from the file
+for f in *_DoseResponse.pdf;do tail -n +11 $f | md5sum;done
+
+echo ".json files"
+# jq complains about formatting, but our json does not have date-specific metadata. We may just calculate md5
+find . -xtype f -name "*.json" | xargs md5sum | sort -V

--- a/tests/compare.sh
+++ b/tests/compare.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+diff -bws $1 $2

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -48,7 +48,10 @@
             "ercc.sampleId": "GCMS_0019"
         },
         "description": "Ercc workflow test",
-        "engineArguments": {},
+        "engineArguments": {
+           "write_to_cache": false,
+           "read_from_cache": false
+        },
         "id": "GCMS_0019_DoseRespose",
         "metadata": {
             "ercc.image": {
@@ -86,8 +89,8 @@
         },
         "validators": [
             {
-                "metrics_calculate": "@CHECKOUT@/./calculate.sh",
-                "metrics_compare": "@CHECKOUT@/./compare.sh",
+                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
+                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
                 "output_metrics": "/.mounts/labs/gsi/testdata/ercc/output_metrics/GCMS_0019_DoseRespose.metrics",
                 "type": "script"
             }


### PR DESCRIPTION
In this implementation we are not using _jq_ since the _.json_ file does not have any date-specific information embedded. No check for _.png_ file, all the other inputs are checked for consistent md5 checksum